### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/antonio-hickey/tradestation-rs/security/code-scanning/1](https://github.com/antonio-hickey/tradestation-rs/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow only checks out code, sets up Python, runs tests, and executes pre-commit checks, it does not need write access to repository contents or other resources. The minimal permission required is `contents: read`. This block can be added either at the root of the workflow (to apply to all jobs) or at the job level. The best practice is to add it at the root level, immediately after the `name` and `on` blocks, so it applies to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
