### PR TITLE
feat(#18): Stream Into Abstractions

### DIFF
--- a/src/accounting/orders.rs
+++ b/src/accounting/orders.rs
@@ -208,6 +208,24 @@ impl Order {
         }
     }
 
+    /// Central facade around [`Order`] 'stream_*_into' methods.
+    async fn _stream_into(
+        endpoint: String,
+        client: &Client,
+        mut callback: impl FnMut(StreamOrdersResp) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        client
+            .stream_into(&endpoint, |stream_event| {
+                let parsed_event: StreamOrdersResp = serde_json::from_value(stream_event)?;
+                callback(parsed_event)?;
+
+                Ok(())
+            })
+            .await?;
+
+        Ok(())
+    }
+
     /// Stream `Order`(s) for the given `Account`.
     pub(super) fn stream<S: Into<String>>(
         account_id: S,
@@ -224,6 +242,17 @@ impl Order {
                 Err(e) => Some(Err(e)),
             }
         })
+    }
+
+    /// Stream [`Order`]'s into a provided callback function.
+    pub(super) async fn stream_into(
+        account_id: impl Into<String>,
+        client: &Client,
+        callback: impl FnMut(StreamOrdersResp) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        let endpoint = format!("brokerage/stream/accounts/{}/orders", account_id.into());
+
+        Order::_stream_into(endpoint, client, callback).await
     }
 
     /// Stream `Order`(s) by order id's for the given `Account`.
@@ -249,6 +278,22 @@ impl Order {
         })
     }
 
+    /// Stream specific [`Order`]'s into a provided callback function.
+    pub(super) async fn stream_by_ids_into(
+        order_ids: Vec<&str>,
+        account_id: impl Into<String>,
+        client: &Client,
+        callback: impl FnMut(StreamOrdersResp) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        let endpoint = format!(
+            "brokerage/stream/accounts/{}/orders/{}",
+            account_id.into(),
+            order_ids.join(",")
+        );
+
+        Order::_stream_into(endpoint, client, callback).await
+    }
+
     /// Stream `Order`(s) for the given `Account`.
     pub(super) fn stream_by_accounts<'a>(
         account_ids: Vec<&'a str>,
@@ -265,6 +310,17 @@ impl Order {
                 Err(e) => Some(Err(e)),
             }
         })
+    }
+
+    /// Stream [`Order`]'s from specific accounts into a provided callback function.
+    pub(super) async fn stream_by_accounts_into(
+        account_ids: Vec<&str>,
+        client: &Client,
+        callback: impl FnMut(StreamOrdersResp) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        let endpoint = format!("brokerage/stream/accounts/{}/orders", account_ids.join(","),);
+
+        Order::_stream_into(endpoint, client, callback).await
     }
 
     /// Stream `Order`s by order id's for the given `Account`(s).
@@ -288,6 +344,21 @@ impl Order {
                 Err(e) => Some(Err(e)),
             }
         })
+    }
+
+    pub(super) async fn stream_by_ids_and_accounts_into(
+        order_ids: Vec<&str>,
+        account_ids: Vec<&str>,
+        client: &Client,
+        callback: impl FnMut(StreamOrdersResp) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        let endpoint = format!(
+            "brokerage/stream/accounts/{}/orders/{}",
+            account_ids.join(","),
+            order_ids.join(","),
+        );
+
+        Order::_stream_into(endpoint, client, callback).await
     }
 }
 


### PR DESCRIPTION
CLOSES: #18 

- [x] Implement a generic top level stream into handler on `Client`.
- [x]  Implement [`Bar::stream_into`|`Client::stream_bars_into`] (Market Data)
- [x]  Implement [`Quote::stream_into`|`Client::stream_quotes_into`] (Market Data)
- [x] Implement [`OptionChain::stream_into`|`Client::stream_option_chain_into`] (Market Data)
- [x] Implement [`OptionQuote::stream_into`|`Client::stream_option_quotes_into`] (Market Data)
- [x] Implement [`MarketDepth::stream_into`|`Client::stream_market_depth_into`] (Market Data)
- [x] Implement [`Client::stream_orders_into`] (Accounting | Execution)
- [x] Implement [`Client::stream_orders_by_ids_into`] (Accounting | Execution)
- [x] Implement [`Client::stream_orders_by_accounts_into`] (Accounting | Execution)
- [x] Implement [`Client::stream_orders_by_ids_and_accounts_into`] (Accounting | Execution)
- [x] Implement [`Client::stream_positions_into`] (Accounting)
- [x] Implement [`Client::stream_positions_for_accounts_into`] (Accounting)