### PR TITLE
fix: make stream error message optional

### DIFF
--- a/src/responses/stream.rs
+++ b/src/responses/stream.rs
@@ -21,8 +21,11 @@ pub struct StreamStatus {
 #[serde(rename_all = "PascalCase")]
 /// A stream response to tell you of an error during stream
 pub struct ErrorResp {
+    /// The title of the error.
     pub error: String,
-    pub message: String,
+
+    /// The description of the error.
+    pub message: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// DEPRECATED: Removed by TradeStation.


### PR DESCRIPTION
Encountered an `ErrorResp` variant with an error of "DualLogon", but no error message provided.
This means there is at least one variant of `ErrorResp` that TradeStation's stream can throw.