### PR TITLE
docs: close market depth example fences

### DIFF
--- a/src/market_data/market_depth.rs
+++ b/src/market_data/market_depth.rs
@@ -140,6 +140,7 @@ impl MarketDepthQuotes {
     ///     Ok(())
     /// }).await?;
     /// # Ok(()) }
+    /// ```
     pub async fn stream_into(
         client: &Client,
         symbol: impl Into<String>,
@@ -447,6 +448,7 @@ impl MarketDepthAggregates {
     ///     Ok(())
     /// }).await?;
     /// # Ok(()) }
+    /// ```
     pub async fn stream_into(
         client: &Client,
         symbol: impl Into<String>,


### PR DESCRIPTION
## Summary

- close the unclosed Rustdoc code fences for the market depth `stream_into` examples
- fixes the issue-reported `MarketDepthAggregates::stream_into` example and the matching `MarketDepthQuotes::stream_into` example in the same file

Closes #66

## Verification

- `cargo fmt --all -- --check`
- `cargo test --doc --locked`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --locked`
- rendered docs smoke check for both market depth examples